### PR TITLE
Modify connect to host for Xdebug

### DIFF
--- a/docker/php/custom.ini
+++ b/docker/php/custom.ini
@@ -18,11 +18,11 @@ display_errors = on
 
 ;Xdebug Config
 xdebug.remote_enable=on
-xdebug.remote_connect_back=1
 xdebug.remote_port=9000
 xdebug.profiler_enable=on
 xdebug.remote_autostart=on
 ;xdebug.remote_log = "/webapp/logfile.log"
+xdebug.remote_host=172.26.0.1
 _realpath_cache_size_ = 4096k
 _realpath_cache_ttl_ = 7200
 xdebug.profiler_output_dir = "/tmp"


### PR DESCRIPTION
Hi, @flyve-mdm/backend-development.

### Changes description

I changed the way to conect the xdebug with the host. I disabled the connect_back in xdebug and i add the remote_host property.

This change is motived by the issue present when runing the unit test in the environment docker with connect_bach enabled.

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ingluife |4|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #26