### PR TITLE
Fixes mysql dependency in php container

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update --fix-missing && apt-get upgrade -y && apt-get install -my wg
 
 # Install iconv, mcrypt, gd
 RUN apt-get install -y cron libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev \
-        git mysql-client libldb-dev libldap2-dev libbz2-dev unzip \
+        git default-mysql-client libldb-dev libldap2-dev libbz2-dev unzip \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd iconv mcrypt
 


### PR DESCRIPTION
### Changes description

The MySQL dependency is deprecated in the Debian repositories. However, I add the package name to resolve the dependency with **default-mysql**

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

[<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->
](https://github.com/flyve-mdm/docker-environment/issues/65)
Closes #65
Related #N/A
Depends on #N/A